### PR TITLE
force a sync so read from shared FS don't fail

### DIFF
--- a/pyflow/src/pyflow.py
+++ b/pyflow/src/pyflow.py
@@ -1173,7 +1173,10 @@ class CommandTaskRunner(BaseTaskRunner) :
                      'cmd' : self.cmd.cmd, 'isShellCmd' : (self.cmd.type == "str") }
 
         argFile = os.path.join(self.tmpDir, "taskWrapperParameters.pickle")
-        pickle.dump(taskInfo, open(argFile, "w"))
+        f = open(argFile, "w")
+        pickle.dump(taskInfo, f)
+        f.flush()
+        f.close()
 
         self.wrapperCmd = [self.taskWrapper, self.runid, self.taskStr, argFile]
 


### PR DESCRIPTION
Some distributed file systems can be configured to not sync on file close.  This can cause reads of the pickled data fail.
This change forces a sync (flush) of the data to prevent potential future read failures.